### PR TITLE
Added null option to fix PHP 8.4 deprecation notices

### DIFF
--- a/src/Recorders/DumpRecorder/MultiDumpHandler.php
+++ b/src/Recorders/DumpRecorder/MultiDumpHandler.php
@@ -16,7 +16,7 @@ class MultiDumpHandler
         }
     }
 
-    public function addHandler(callable $callable = null): self
+    public function addHandler(callable|null $callable = null): self
     {
         $this->handlers[] = $callable;
 


### PR DESCRIPTION
PHP 8.4 throws a deprecation warning because null can't be implicitly defined. This fix addresses the deprecation warning that gets emitted.

```
PHP Deprecated:  Spatie\LaravelFlare\Recorders\DumpRecorder\MultiDumpHandler::addHandler(): Implicitly marking parameter $callable as nullable is deprecated, the explicit nullable type must be used instead in /home/website/htdocs/releases/11/vendor/spatie/laravel-flare/src/Recorders/DumpRecorder/MultiDumpHandler.php on line 19
```