### PR TITLE
Move registerShareButton call in FlareServiceProvider

### DIFF
--- a/src/FlareServiceProvider.php
+++ b/src/FlareServiceProvider.php
@@ -57,6 +57,8 @@ class FlareServiceProvider extends ServiceProvider
             $this->config = $this->app->make(FlareConfig::class);
         }
 
+        $this->registerShareButton();
+
         if (empty($this->config->apiToken)) {
             $this->app->singleton(Flare::class, fn () => new DisabledFlare());
 
@@ -88,8 +90,6 @@ class FlareServiceProvider extends ServiceProvider
         ));
 
         $this->app->singleton(ViewFrameMapper::class);
-
-        $this->registerShareButton();
 
         if ($this->config->trace === false) {
             return;


### PR DESCRIPTION
When we locally do not set an apiToken, then the register() method returns early, therefore "ignoring" the config for `'enable_share_button' => false`.

This change would move the registerShareButton() call directly after fetching the config data.