### PR TITLE
Wrap controller dispatch with a Controller span

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -138,6 +138,14 @@ public function post(string $endpoint, string $apiKey, array $payload, FlareEnti
 
 `LaravelHttpSender` and `LaravelVaporSender` were updated accordingly. The Vapor sender also gained a `queue_logs` config option and no longer queues test payloads.
 
+#### Routing spans rearranged
+
+The HTTP entry-point trace now records the controller and after-middleware phases explicitly.
+
+* The `Response` span has been renamed to `Controller` and now wraps the controller dispatch itself, not the time after it.
+* A new `Middleware (after)` span covers the time between the controller returning and `RequestHandled` firing.
+* `Flare::response()` is replaced by `Flare::controller()`. If you reference the recorder, recorder-type enum, or span-type enum directly, see the matching `ResponseRecorder` entry in the `flare-client-php` upgrade guide.
+
 #### The base Flare client package
 
 The base `spatie/flare-client-php` package was rewritten. Most laravel-flare users do not touch it directly, but if you do (custom samplers, senders, or recorders, vanilla PHP integrations), read its [upgrade guide](https://github.com/spatie/flare-client-php/blob/main/UPGRADING.md) as well.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "illuminate/support": "^11.47|^12.42|^13.0",
-        "spatie/flare-client-php": "dev-sampling-and-entry-point",
+        "spatie/flare-client-php": "dev-controller-recorder",
         "spatie/laravel-error-share": "^1.0.3",
         "symfony/console": "^7.2.1|^8.0",
         "symfony/var-dumper": "^7.2.3|^8.0"

--- a/src/Facades/Flare.php
+++ b/src/Facades/Flare.php
@@ -7,8 +7,8 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Support\Facades\Facade;
 use Spatie\FlareClient\Flare as FlareClient;
+use Spatie\FlareClient\Recorders\ControllerRecorder\ControllerRecorder;
 use Spatie\FlareClient\Recorders\GlowRecorder\GlowRecorder;
-use Spatie\FlareClient\Recorders\ResponseRecorder\ResponseRecorder;
 use Spatie\FlareClient\Tracer;
 use Spatie\LaravelFlare\FlareConfig;
 use Spatie\LaravelFlare\Recorders\FilesystemRecorder\FilesystemRecorder;
@@ -24,7 +24,7 @@ use Throwable;
  * @method static GlowRecorder|null glow()
  * @method static FilesystemRecorder|null filesystem()
  * @method static RoutingRecorder|null routing()
- * @method static ResponseRecorder|null response()
+ * @method static ControllerRecorder|null controller()
  * @method static RequestRecorder|null request()
  * @method static Tracer tracer()
  * @see \Spatie\FlareClient\Flare

--- a/src/Http/RouteDispatchers/Concerns/DispatchesRoutes.php
+++ b/src/Http/RouteDispatchers/Concerns/DispatchesRoutes.php
@@ -10,11 +10,13 @@ trait DispatchesRoutes
     protected function wrapDispatcher(Closure $dispatch): mixed
     {
         Flare::routing()?->recordBeforeMiddlewareEnd();
+        Flare::controller()?->recordStart();
 
-        $dispatched = $dispatch();
-
-        Flare::response()?->recordStart();
-
-        return $dispatched;
+        try {
+            return $dispatch();
+        } finally {
+            Flare::controller()?->recordEnd();
+            Flare::routing()?->recordAfterMiddlewareStart();
+        }
     }
 }

--- a/src/Recorders/RoutingRecorder/RoutingRecorder.php
+++ b/src/Recorders/RoutingRecorder/RoutingRecorder.php
@@ -62,8 +62,8 @@ class RoutingRecorder extends BaseRoutingRecorder
             Flare::routing()?->recordGlobalBeforeMiddlewareEnd();
             Flare::routing()?->recordBeforeMiddlewareEnd();
             Flare::routing()?->recordRoutingEnd(FlareTracingMiddleware::$routeAttributesProvider);
-
-            Flare::response()?->recordEnd();
+            Flare::controller()?->recordEnd();
+            Flare::routing()?->recordAfterMiddlewareEnd();
         });
     }
 }

--- a/src/Support/CollectsResolver.php
+++ b/src/Support/CollectsResolver.php
@@ -6,6 +6,7 @@ use Livewire\Livewire;
 use Spatie\FlareClient\Contracts\FlareCollectType;
 use Spatie\FlareClient\Enums\CollectType;
 use Spatie\FlareClient\FlareMiddleware\AddJobInformation;
+use Spatie\FlareClient\Recorders\ControllerRecorder\ControllerRecorder;
 use Spatie\FlareClient\Support\CollectsResolver as BaseCollectsResolver;
 use Spatie\LaravelFlare\Enums\LaravelCollectType;
 use Spatie\LaravelFlare\FlareMiddleware\AddConsoleInformation;
@@ -78,6 +79,7 @@ class CollectsResolver extends BaseCollectsResolver
             RoutingRecorder::class,
             $this->only($options, ['ignored_routes']),
         );
+        $this->addRecorder(ControllerRecorder::class);
     }
 
     protected function console(array $options): void

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -43,7 +43,7 @@ describe('Laravel integration', function () {
         $workspace->assertSent(traces: 1);
 
         $trace = $workspace->lastTrace()
-            ->expectSpanCount(9)
+            ->expectSpanCount(11)
             ->expectLaravelRequestLifecycle();
 
         $trace->expectSpan(SpanType::Request)
@@ -88,7 +88,7 @@ describe('Laravel integration', function () {
         $workspace->assertSent(traces: 1);
 
         $trace = $workspace->lastTrace()
-            ->expectSpanCount(10)
+            ->expectSpanCount(12)
             ->expectLaravelRequestLifecycle();
 
         $trace->expectSpan(SpanType::Request)->expectAttribute('http.response.status_code', 403);
@@ -548,7 +548,9 @@ describe('Laravel integration', function () {
         $foundTrackingUuid = null;
 
         $trace->expectSpan(SpanType::Request)
-            ->expectAttribute('http.response.status_code', 500)
+            ->expectAttribute('http.response.status_code', 500);
+
+        $trace->expectSpan(SpanType::AfterMiddleware)
             ->expectSpanEventCount(1)
             ->expectSpanEvent(0)
             ->expectType(SpanEventType::Exception)
@@ -577,7 +579,9 @@ describe('Laravel integration', function () {
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
         $trace->expectSpan(SpanType::Request)
-            ->expectAttribute('http.response.status_code', 200)
+            ->expectAttribute('http.response.status_code', 200);
+
+        $trace->expectSpan(SpanType::Controller)
             ->expectSpanEventCount(1)
             ->expectSpanEvent(0)
             ->expectType(SpanEventType::Exception)
@@ -599,8 +603,8 @@ describe('Laravel integration', function () {
         $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 500);
 
-        $trace->expectSpan(7) // The error page generates a massive amount of view spans
-        ->expectSpanEventCount(1)
+        $trace->expectSpan(SpanType::AfterMiddleware)
+            ->expectSpanEventCount(1)
             ->expectSpanEvent(0)
             ->expectType(SpanEventType::Exception);
 
@@ -618,8 +622,8 @@ describe('Laravel integration', function () {
         $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 500);
 
-        $trace->expectSpan(7) // The error page generates a massive amount of view spans
-        ->expectSpanEventCount(1)
+        $trace->expectSpan(SpanType::AfterMiddleware)
+            ->expectSpanEventCount(1)
             ->expectSpanEvent(0)
             ->expectType(SpanEventType::Exception);
 
@@ -639,11 +643,13 @@ describe('Laravel integration', function () {
 
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
-        $requestSpan = $trace->expectSpan(SpanType::Request)
+        $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $trace->expectSpan(SpanType::Query)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('db.system', 'sqlite')
             ->expectHasAttribute('db.name')
             ->expectAttribute('db.statement', 'select * from "posts" limit 1')
@@ -658,20 +664,22 @@ describe('Laravel integration', function () {
 
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
-        $requestSpan = $trace->expectSpan(SpanType::Request)
+        $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
+
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
 
         $trace->expectSpans(
             SpanType::Query,
             fn (ExpectSpan $span) => $span
-                ->expectParentId($requestSpan)
+                ->expectParentId($controllerSpan)
                 ->expectAttribute('db.system', 'sqlite')
                 ->expectHasAttribute('db.name')
                 ->expectAttribute('db.statement', 'select * from "posts" where "id" = ? limit 1')
                 ->expectAttribute('db.sql.bindings', [1])
                 ->expectAttribute('laravel.db.connection', 'sqlite'),
             fn (ExpectSpan $span) => $span
-                ->expectParentId($requestSpan)
+                ->expectParentId($controllerSpan)
                 ->expectAttribute('db.system', 'sqlite')
                 ->expectHasAttribute('db.name')
                 ->expectAttribute('db.statement', 'select * from "posts" where "name" = ? limit 1')
@@ -687,11 +695,13 @@ describe('Laravel integration', function () {
 
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
-        $requestSpan = $trace->expectSpan(SpanType::Request)
+        $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $transactionSpan = $trace->expectSpan(SpanType::Transaction)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('laravel.db.connection', 'sqlite')
             ->expectAttribute('db.transaction.status', 'committed');
 
@@ -706,11 +716,13 @@ describe('Laravel integration', function () {
 
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
-        $requestSpan = $trace->expectSpan(SpanType::Request)
+        $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 500);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $transactionSpan = $trace->expectSpan(SpanType::Transaction)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('laravel.db.connection', 'sqlite')
             ->expectAttribute('db.transaction.status', 'rolled_back');
 
@@ -728,7 +740,9 @@ describe('Laravel integration', function () {
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
         $trace->expectSpan(SpanType::Request)
-            ->expectAttribute('http.response.status_code', 200)
+            ->expectAttribute('http.response.status_code', 200);
+
+        $trace->expectSpan(SpanType::Controller)
             ->expectSpanEvents(
                 SpanEventType::Cache,
                 fn (ExpectSpanEvent $event) => $event
@@ -768,11 +782,13 @@ describe('Laravel integration', function () {
 
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
-        $requestSpan = $trace->expectSpan(SpanType::Request)
+        $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $trace->expectSpan(SpanType::HttpRequest)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('http.request.method', 'GET')
             ->expectAttribute('url.full', 'https://jsonplaceholder.typicode.com/posts/1')
             ->expectAttribute('server.address', 'jsonplaceholder.typicode.com')
@@ -790,11 +806,13 @@ describe('Laravel integration', function () {
 
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
-        $requestSpan = $trace->expectSpan(SpanType::Request)
+        $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $trace->expectSpan(SpanType::HttpRequest)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('http.request.method', 'POST')
             ->expectAttribute('url.full', 'https://jsonplaceholder.typicode.com/posts')
             ->expectAttribute('server.address', 'jsonplaceholder.typicode.com')
@@ -812,15 +830,18 @@ describe('Laravel integration', function () {
 
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
-        $requestSpan = $trace->expectSpan(SpanType::Request)
+        $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 500);
 
-        $requestSpan->expectSpanEventCount(1)
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
+        $trace->expectSpan(SpanType::AfterMiddleware)
+            ->expectSpanEventCount(1)
             ->expectSpanEvent(0)
             ->expectType(SpanEventType::Exception);
 
         $trace->expectSpan(SpanType::HttpRequest)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('http.request.method', 'GET')
             ->expectAttribute('url.full', 'https://does-not-exist-invalid-domain-12345.com')
             ->expectMissingAttribute('http.response.status_code')
@@ -840,19 +861,21 @@ describe('Laravel integration', function () {
 
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
-        $requestSpan = $trace->expectSpan(SpanType::Request)
+        $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
+
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
 
         $trace->expectSpans(
             SpanType::Filesystem,
             fn (ExpectSpan $span) => $span
-                ->expectParentId($requestSpan)
+                ->expectParentId($controllerSpan)
                 ->expectAttribute('filesystem.operation', 'put')
                 ->expectAttribute('filesystem.path', 'example.txt')
                 ->expectAttribute('filesystem.contents.size', '8 B')
                 ->expectAttribute('filesystem.operation.success', true),
             fn (ExpectSpan $span) => $span
-                ->expectParentId($requestSpan)
+                ->expectParentId($controllerSpan)
                 ->expectAttribute('filesystem.operation', 'get')
                 ->expectAttribute('filesystem.path', 'example.txt')
                 ->expectAttribute('filesystem.contents.size', '8 B'),
@@ -871,8 +894,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $queuingSpan = $httpTrace->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('laravel.job.queue.connection_name', 'database')
             ->expectAttribute('laravel.job.queue.name', 'default')
             ->expectHasAttribute('laravel.job.uuid')
@@ -910,8 +935,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $queuingSpan = $httpTrace->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('laravel.job.queue.connection_name', 'database')
             ->expectAttribute('laravel.job.queue.name', 'default')
             ->expectHasAttribute('laravel.job.uuid')
@@ -949,8 +976,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $queuingSpan = $httpTrace->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan);
+            ->expectParentId($controllerSpan);
 
         $jobTrace = $workspace->trace(1)
             ->expectSpanCount(5); // Job, transaction: select and remove job, plus the failed attempt
@@ -1071,9 +1100,11 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $queuingSpan = $httpTrace
             ->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectTraceId($requestSpan->span['traceId']);
 
         $job1Span = $workspace->trace(1)
@@ -1112,8 +1143,10 @@ describe('Laravel integration', function () {
         $requestSpan = $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $trace->expectSpan(SpanType::Job)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('laravel.job.queue.connection_name', 'sync')
             ->expectAttribute('laravel.job.queue.name', 'sync')
             ->expectAttribute('laravel.job.name', SuccesJob::class)
@@ -1135,8 +1168,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $queuingSpan = $httpTrace->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan);
+            ->expectParentId($controllerSpan);
 
         $workspace->trace(1)
             ->expectSpan(SpanType::Job)
@@ -1180,8 +1215,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $queuingSpan = $httpTrace->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan);
+            ->expectParentId($controllerSpan);
 
         for ($i = 1; $i <= 4; $i++) {
             $workspace->trace($i)
@@ -1226,8 +1263,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $queuingSpan = $httpTrace->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('laravel.job.class', NestedJob::class);
 
         $nestedJobTrace = $workspace->trace(1);
@@ -1261,8 +1300,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $httpTrace->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('laravel.job.class', ExitingJob::class);
     })->skip('This kills the queue process, so do not test this');
 
@@ -1276,8 +1317,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $queuingSpan = $httpTrace->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('laravel.job.class', ReleaseJob::class);
 
         $jobTrace = $workspace->trace(1);
@@ -1313,8 +1356,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $queuingSpan = $httpTrace->expectSpan(SpanType::QueueingJob)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('laravel.job.class', DeletedJob::class);
 
         $jobTrace = $workspace->trace(1);
@@ -1337,8 +1382,10 @@ describe('Laravel integration', function () {
         $requestSpan = $httpTrace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $httpTrace->expectSpan(SpanType::Controller);
+
         $transactionSpan = $httpTrace->expectSpan(SpanType::Transaction)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('db.transaction.status', 'committed');
 
         $httpTrace->expectSpans(
@@ -1399,9 +1446,11 @@ describe('Laravel integration', function () {
         $requestSpan = $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $componentSpan = $trace
             ->expectSpan(LaravelSpanType::LivewireComponent)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('livewire.component.class', Counter::class)
             ->expectAttribute('livewire.component.name', 'counter')
             ->expectAttribute('livewire.component.single_file_component', false)
@@ -1425,7 +1474,7 @@ describe('Laravel integration', function () {
                 ->expectAttribute('view.name', 'livewire.counter')
                 ->expectHasAttribute('view.file'),
             fn (ExpectSpan $span) => $span
-                ->expectParentId($requestSpan)
+                ->expectParentId($controllerSpan)
                 ->expectAttribute('view.name', 'components.layouts.app')
                 ->expectHasAttribute('view.file'),
         );
@@ -1445,9 +1494,11 @@ describe('Laravel integration', function () {
         $requestSpan = $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $componentSpan = $trace
             ->expectSpan(LaravelSpanType::LivewireComponent)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('livewire.component.class', Inline::class)
             ->expectAttribute('livewire.component.name', 'inline')
             ->expectAttribute('livewire.component.single_file_component', false)
@@ -1468,7 +1519,7 @@ describe('Laravel integration', function () {
         $trace->expectSpans(
             SpanType::View,
             fn (ExpectSpan $span) => $span
-                ->expectParentId($requestSpan)
+                ->expectParentId($controllerSpan)
                 ->expectAttribute('view.name', 'components.layouts.app'),
         );
 
@@ -1487,9 +1538,11 @@ describe('Laravel integration', function () {
         $requestSpan = $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $componentSpan = $trace
             ->expectSpan(LaravelSpanType::LivewireComponent)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('livewire.component.name', 'single-file-counter')
             ->expectAttribute('livewire.component.single_file_component', true)
             ->expectMissingAttribute('livewire.component.class')
@@ -1514,7 +1567,7 @@ describe('Laravel integration', function () {
                 ->expectAttribute('view.file', fn (string $value) => expect($value)->toEndWith('single-file-counter.blade.php'))
                 ->expectAttribute('view.is_livewire_single_file_component', true),
             fn (ExpectSpan $span) => $span
-                ->expectParentId($requestSpan)
+                ->expectParentId($controllerSpan)
                 ->expectAttribute('view.name', 'components.layouts.app'),
         );
 
@@ -1536,11 +1589,13 @@ describe('Laravel integration', function () {
         $requestSpan = $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 200);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $trace->expectSpans(
             LaravelSpanType::LivewireComponent,
-            function (ExpectSpan $span) use ($requestSpan, &$nestedSpan) {
+            function (ExpectSpan $span) use ($controllerSpan, &$nestedSpan) {
                 $nestedSpan = $span
-                    ->expectParentId($requestSpan)
+                    ->expectParentId($controllerSpan)
                     ->expectAttribute('livewire.component.name', 'nested');
             },
             function (ExpectSpan $span) use (&$nestedSpan) {
@@ -1562,8 +1617,10 @@ describe('Laravel integration', function () {
         $requestSpan = $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 500);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $componentSpan = $trace->expectSpan(LaravelSpanType::LivewireComponent)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('livewire.component.name', 'mount-exception')
             ->expectHasAttribute('livewire.component.phase.mounting');
 
@@ -1589,8 +1646,10 @@ describe('Laravel integration', function () {
         $requestSpan = $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 500);
 
+        $controllerSpan = $trace->expectSpan(SpanType::Controller);
+
         $componentSpan = $trace->expectSpan(LaravelSpanType::LivewireComponent)
-            ->expectParentId($requestSpan)
+            ->expectParentId($controllerSpan)
             ->expectAttribute('livewire.component.name', 'view-exception')
             ->expectAttribute('livewire.component.class', \Workbench\App\Livewire\ViewException::class)
             ->expectHasAttribute('livewire.component.phase.mounting');
@@ -1647,8 +1706,11 @@ describe('Laravel integration', function () {
 
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
-        $responseSpan = $trace->expectSpan(SpanType::Request)
+        $trace->expectSpan(SpanType::Request)
             ->expectAttribute('http.response.status_code', 500)
+            ->expectSpanEventCount(0, SpanEventType::Log);
+
+        $controllerSpan = $trace->expectSpan(SpanType::Controller)
             ->expectSpanEventCount(0, SpanEventType::Log);
 
         $log = $workspace->log(0)->expectLogCount(8);
@@ -1661,7 +1723,7 @@ describe('Laravel integration', function () {
             ->expectAttribute('flare.entry_point.handler.type', 'laravel_closure')
             ->expectSeverityText('debug')
             ->expectSeverityNumber(5)
-            ->expectMatchesSpan($responseSpan)
+            ->expectMatchesSpan($controllerSpan)
             ->expectSampling();
 
         $log->expectLog(1)
@@ -1669,7 +1731,7 @@ describe('Laravel integration', function () {
             ->expectAttribute('log.context', [])
             ->expectSeverityText('info')
             ->expectSeverityNumber(9)
-            ->expectMatchesSpan($responseSpan)
+            ->expectMatchesSpan($controllerSpan)
             ->expectSampling();
 
         $log->expectLog(2)
@@ -1677,7 +1739,7 @@ describe('Laravel integration', function () {
             ->expectAttribute('log.context', [])
             ->expectSeverityText('notice')
             ->expectSeverityNumber(10)
-            ->expectMatchesSpan($responseSpan)
+            ->expectMatchesSpan($controllerSpan)
             ->expectSampling();
 
         $log->expectLog(3)
@@ -1685,7 +1747,7 @@ describe('Laravel integration', function () {
             ->expectAttribute('log.context', [])
             ->expectSeverityText('warning')
             ->expectSeverityNumber(13)
-            ->expectMatchesSpan($responseSpan)
+            ->expectMatchesSpan($controllerSpan)
             ->expectSampling();
 
         $log->expectLog(4)
@@ -1693,7 +1755,7 @@ describe('Laravel integration', function () {
             ->expectAttribute('log.context', [])
             ->expectSeverityText('error')
             ->expectSeverityNumber(17)
-            ->expectMatchesSpan($responseSpan)
+            ->expectMatchesSpan($controllerSpan)
             ->expectSampling();
 
         $log->expectLog(5)
@@ -1701,7 +1763,7 @@ describe('Laravel integration', function () {
             ->expectAttribute('log.context', [])
             ->expectSeverityText('critical')
             ->expectSeverityNumber(18)
-            ->expectMatchesSpan($responseSpan)
+            ->expectMatchesSpan($controllerSpan)
             ->expectSampling();
 
         $log->expectLog(6)
@@ -1709,7 +1771,7 @@ describe('Laravel integration', function () {
             ->expectAttribute('log.context', [])
             ->expectSeverityText('alert')
             ->expectSeverityNumber(19)
-            ->expectMatchesSpan($responseSpan)
+            ->expectMatchesSpan($controllerSpan)
             ->expectSampling();
 
         $log->expectLog(7)
@@ -1717,7 +1779,7 @@ describe('Laravel integration', function () {
             ->expectAttribute('log.context', [])
             ->expectSeverityText('emergency')
             ->expectSeverityNumber(21)
-            ->expectMatchesSpan($responseSpan)
+            ->expectMatchesSpan($controllerSpan)
             ->expectSampling();
 
         $workspace->lastReport()
@@ -1772,7 +1834,9 @@ describe('Laravel integration', function () {
         $trace = $workspace->lastTrace()->expectLaravelRequestLifecycle();
 
         $trace->expectSpan(SpanType::Request)
-            ->expectAttribute('http.response.status_code', 500)
+            ->expectAttribute('http.response.status_code', 500);
+
+        $trace->expectSpan(SpanType::Controller)
             ->expectSpanEvents(
                 SpanEventType::Glow,
                 fn (ExpectSpanEvent $event) => $event


### PR DESCRIPTION
## Summary

Companion change to the `spatie/flare-client-php` `ResponseRecorder` rename: replaces the old `Response` span with a new `Controller` span that actually wraps `$dispatch()`, and adds a `Middleware (after)` span for the time between the controller returning and `RequestHandled` firing.

## Why

While debugging missing spans we found two issues:

1. `LaravelFlare\Support\CollectsResolver::requests()` overrides the parent and never called `addRecorder(ResponseRecorder::class)`, so `Flare::response()` was always null and the span never appeared.
2. The recorder labelled `Response` was started **after** `$dispatch()` returned, so semantically it covered the after-middleware time. The actual controller execution was not wrapped at all, and any in-dispatch spans (queries, views, etc.) had `Request` as their parent rather than the controller they ran inside.

## Changes

- `DispatchesRoutes::wrapDispatcher`: opens `Controller` before `$dispatch()`, closes it and starts `Middleware (after)` in `finally`. The `try/finally` ensures both happen even when the controller throws.
- `RoutingRecorder` `RequestHandled` listener: closes the `Controller` and `Middleware (after)` spans (replacing the old `response()->recordEnd()` no-op).
- `CollectsResolver::requests()`: registers the renamed `ControllerRecorder`.
- `Flare` facade docblock: `response()` → `controller()`.
- Integration tests updated for the new hierarchy. Query / cache / view / glow / livewire / external HTTP / queueing spans now expect `Controller` as their parent. Exception events for unhandled exceptions land on `AfterMiddleware` (handled exceptions on `Controller`).

## Caveats

- Depends on the matching `ControllerRecorder` rename in `spatie/flare-client-php` (separate PR). Wire format value is now `php_controller`; server-side ingestion needs the corresponding update.
- The exception-event placement on `AfterMiddleware` is a side effect of when Laravel calls `$exceptionHandler->report()` relative to our `finally`. Worth revisiting once we've used the new shape in real traces.