### PR TITLE
Quote string bindings in QueryException error messages

### DIFF
--- a/src/FlareMiddleware/AddExceptionContextInformation.php
+++ b/src/FlareMiddleware/AddExceptionContextInformation.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelFlare\FlareMiddleware;
 use Closure;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Spatie\FlareClient\Contracts\ProvidesFlareContext;
 use Spatie\FlareClient\FlareMiddleware\FlareMiddleware;
 use Spatie\FlareClient\ReportFactory;
@@ -34,7 +35,34 @@ class AddExceptionContextInformation implements FlareMiddleware
             // Skip this
         }
 
+        $this->rewriteQueryExceptionMessage($report);
+
         return $next($report);
+    }
+
+    private function rewriteQueryExceptionMessage(ReportFactory $report): void
+    {
+        if ($report->message === null) {
+            return;
+        }
+
+        if (! preg_match('/^(.*, SQL: ).+\)$/s', $report->message, $matches)) {
+            return;
+        }
+
+        /** @var QueryException $throwable */
+        $throwable = $report->throwable;
+
+        $bindings = array_map(fn ($value) => match (true) {
+            $value === null => 'NULL',
+            is_bool($value) => $value ? '1' : '0',
+            is_int($value), is_float($value) => (string) $value,
+            default => "'".str_replace("'", "''", (string) $value)."'",
+        }, $throwable->getBindings());
+
+        $sql = Str::replaceArray('?', $bindings, $throwable->getSql());
+
+        $report->message = $matches[1].$sql.')';
     }
 
     private function addUserDefinedContext(

--- a/tests/FlareMiddleware/AddExceptionInformationTest.php
+++ b/tests/FlareMiddleware/AddExceptionInformationTest.php
@@ -21,6 +21,64 @@ it('will add query information with a query exception', function () {
     expect($attributes['flare.exception.db_statement'])->toBe($sql);
 });
 
+it('rewrites the query exception message with quoted string bindings', function () {
+    setupFlare();
+
+    $exception = new QueryException(
+        'sqlite',
+        'delete from "users" where "ref_id" in (?, ?)',
+        ['019e4430-4bce-73fa-a8fb-6fedc84e6fd2', '019e4430-4bce-73fa-a8fb-6fedc8f854f2'],
+        new Exception('SQLSTATE[HY000]: General error: 1020 Record has changed'),
+    );
+
+    $originalMessage = $exception->getMessage();
+
+    $report = Flare::report($exception)->toArray();
+
+    expect($report['message'])->toBe(
+        'SQLSTATE[HY000]: General error: 1020 Record has changed (Connection: sqlite, SQL: delete from "users" where "ref_id" in (\'019e4430-4bce-73fa-a8fb-6fedc84e6fd2\', \'019e4430-4bce-73fa-a8fb-6fedc8f854f2\'))'
+    );
+    expect($exception->getMessage())->toBe($originalMessage);
+});
+
+it('correctly substitutes every supported binding type', function () {
+    setupFlare();
+
+    $sql = 'select * from "t" where "a" = ? and "b" = ? and "c" = ? and "d" = ? and "e" = ? and "f" = ? and "g" is ? and "h" = ? and "i" = ?';
+    $bindings = ['hello', "O'Brien", 42, 3.14, true, false, null, 0, ''];
+
+    $exception = new QueryException(
+        'sqlite',
+        $sql,
+        $bindings,
+        new Exception('SQLSTATE[HY000]: boom'),
+    );
+
+    $report = Flare::report($exception)->toArray();
+
+    expect($report['message'])->toBe(
+        'SQLSTATE[HY000]: boom (Connection: sqlite, SQL: select * from "t" where "a" = \'hello\' and "b" = \'O\'\'Brien\' and "c" = 42 and "d" = 3.14 and "e" = 1 and "f" = 0 and "g" is NULL and "h" = 0 and "i" = \'\')'
+    );
+});
+
+it('leaves the report message untouched when the format is unexpected', function () {
+    setupFlare();
+
+    $exception = new QueryException(
+        'sqlite',
+        'select * from "users" where "id" = ?',
+        [1],
+        new Exception('SQLSTATE[HY000]: boom'),
+    );
+
+    (new ReflectionProperty(Exception::class, 'message'))
+        ->setValue($exception, 'something completely different without the expected suffix');
+
+    $report = Flare::report($exception)->toArray();
+
+    expect($report['message'])->toBe('something completely different without the expected suffix');
+});
+
 it('wont add query information without a query exception', function () {
     setupFlare();
 


### PR DESCRIPTION
## Summary

Laravel's `QueryException::formatMessage` inlines bindings with `Str::replaceArray` and no quoting, producing exception messages like:

```
SQLSTATE[HY000]: ... (Connection: local, ..., SQL: delete from `of_many_caches` where `ref_id` in (019e4430-4bce-73fa-a8fb-6fedc84e6fd2, 019e4430-4bce-73fa-a8fb-6fedc8f854f2))
```

That SQL isn't valid (UUID strings aren't quoted) so it can't be copy-pasted out of Flare. This change rewrites the `, SQL: ...)` portion of the report message:

- `null` becomes `NULL` (unquoted keyword).
- Booleans become `0` / `1`.
- Ints and floats render as-is.
- Everything else gets wrapped in single quotes with inner `'` doubled (SQL-standard `''` escape, accepted by PostgreSQL, MySQL, MariaDB and SQLite).

The substitution then runs through `Str::replaceArray` exactly like Laravel's own `formatMessage`, so the format stays identical apart from the now-quoted values.

Only `$report->message` is touched; the throwable itself is left intact so other handlers still see Laravel's original message. If the message doesn't match the expected `..., SQL: ...)` shape the middleware bails out without changes.