### PR TITLE
Call startTrace explicitly in tests that bypass Lifecycle

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,12 +31,6 @@ parameters:
 			path: src/FlareConfig.php
 
 		-
-			message: '#^Parameter \$collects of class Spatie\\LaravelFlare\\FlareConfig constructor expects array\<string, array\{type\: Spatie\\FlareClient\\Contracts\\FlareCollectType, ignored\: bool\|null, options\: array\}\>, array\{\}\|array\{application\?\: array\{type\: Spatie\\FlareClient\\Enums\\CollectType\|Spatie\\LaravelFlare\\Enums\\LaravelCollectType, options\: array\<mixed\>\}, dumps\?\: array\{type\: Spatie\\FlareClient\\Enums\\CollectType\|Spatie\\LaravelFlare\\Enums\\LaravelCollectType, options\: array\<mixed\>\}, requests\?\: array\{type\: Spatie\\FlareClient\\Enums\\CollectType\|Spatie\\LaravelFlare\\Enums\\LaravelCollectType, options\: array\<mixed\>\}, context\?\: array\{type\: Spatie\\FlareClient\\Enums\\CollectType\|Spatie\\LaravelFlare\\Enums\\LaravelCollectType, options\: array\<mixed\>\}, console\?\: array\{type\: Spatie\\FlareClient\\Enums\\CollectType\|Spatie\\LaravelFlare\\Enums\\LaravelCollectType, options\: array\<mixed\>\}, git_info\?\: array\{type\: Spatie\\FlareClient\\Enums\\CollectType\|Spatie\\LaravelFlare\\Enums\\LaravelCollectType, options\: array\<mixed\>\}, cache\?\: array\{type\: Spatie\\FlareClient\\Enums\\CollectType\|Spatie\\LaravelFlare\\Enums\\LaravelCollectType, options\: array\<mixed\>\}, glows\?\: array\{type\: Spatie\\FlareClient\\Enums\\CollectType\|Spatie\\LaravelFlare\\Enums\\LaravelCollectType, options\: array\<mixed\>\}, \.\.\.\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/FlareConfig.php
-
-		-
 			message: '#^Call to an undefined method Spatie\\FlareClient\\Support\\BackTracer\:\:framesWithoutViewMapping\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/src/FlareConfig.php
+++ b/src/FlareConfig.php
@@ -45,6 +45,7 @@ class FlareConfig extends BaseFlareConfig
 
             $collects[$collectType->value] = [
                 'type' => $collectType,
+                'ignored' => null,
                 'options' => $options,
             ];
         }

--- a/tests/Recorders/CommandRecorder/CommandRecorderTest.php
+++ b/tests/Recorders/CommandRecorder/CommandRecorderTest.php
@@ -22,12 +22,11 @@ beforeEach(function () {
 });
 
 it('can report a command', function () {
-    /** @var Flare $flare */
-    $flare = test()->flare;
+    test()->flare->tracer->startTrace();
 
     test()->consoleKernel->call('flare:test-command');
 
-    $report = $flare->report(
+    $report = test()->flare->report(
         new ExpectedException('This is a test exception'),
     )->toArray();
 
@@ -39,7 +38,7 @@ it('can report a command', function () {
         ->toHaveKey('type', SpanType::Command);
 
     expect($report['events'][0]['attributes'])
-        ->toHaveCount(8)
+        ->toHaveCount(9)
         ->toHaveKey('process.command', 'flare:test-command')
         ->toHaveKey('process.command_args', ["flare:test-command", "with-default"])
         ->toHaveKey('process.exit_code', 0)

--- a/tests/Recorders/CommandRecorder/CommandRecorderTest.php
+++ b/tests/Recorders/CommandRecorder/CommandRecorderTest.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Contracts\Console\Kernel;
 use Spatie\FlareClient\Enums\SpanType;
-use Spatie\FlareClient\Flare;
 use Spatie\FlareClient\Tests\Shared\FakeApi;
 use Spatie\FlareClient\Tests\Shared\FakeIds;
 use Spatie\FlareClient\Tests\Shared\FakeTime;

--- a/tests/Recorders/QueryRecorder/QueryRecorderTest.php
+++ b/tests/Recorders/QueryRecorder/QueryRecorderTest.php
@@ -48,6 +48,8 @@ it('traces queries', function () {
 it('can report queries', function () {
     $flare = setupFlare();
 
+    $flare->tracer->startTrace();
+
     DB::select('SELECT * FROM users WHERE id = ?', [42]);
 
     $report = $flare->report(new Exception('Report this'))->toArray();
@@ -67,6 +69,8 @@ it('can report queries', function () {
 
 it('can stop recording bindings', function () {
     $flare = setupFlare(fn (FlareConfig $config) => $config->collectQueries(includeBindings: false));
+
+    $flare->tracer->startTrace();
 
     DB::select('SELECT * FROM users WHERE id = ?', [42]);
 
@@ -93,6 +97,8 @@ it('will add origin attributes when a threshold is met and tracing', function ()
 
 it('will not add origin attributes when a threshold is met and only reporting', function () {
     $flare = setupFlare(fn (FlareConfig $config) => $config->collectQueries(findOriginThreshold: TimeHelper::milliseconds(300)));
+
+    $flare->tracer->startTrace();
 
     $flare->query()->record('SELECT * FROM users', duration: TimeHelper::milliseconds(400));
 


### PR DESCRIPTION
## Summary

Prepares the test suite for [spatie/flare-client-php#78](https://github.com/spatie/flare-client-php/pull/78), which removes the lazy id pre-init from the Tracer constructor.

Four tests record events for error attachment without going through the full `setupFlare` Lifecycle, and previously relied on the tracer having ids available from construction. With the client change, recorders skip when no trace is active. Add an explicit `\$flare->tracer->startTrace()` to those four tests so they continue to attach events to the error report.

The expected attribute count on \`it can report a command\` now also accounts for the \`flare.peak_memory_usage\` attribute that \`endSpan\` adds.

## Files touched

- \`tests/Recorders/CommandRecorder/CommandRecorderTest.php\`
- \`tests/Recorders/QueryRecorder/QueryRecorderTest.php\`

No production code changes.