### PR TITLE
Fix failing CI: undefined variable in CommandRecorderTest

### DIFF
--- a/tests/Recorders/CommandRecorder/CommandRecorderTest.php
+++ b/tests/Recorders/CommandRecorder/CommandRecorderTest.php
@@ -23,8 +23,6 @@ beforeEach(function () {
 it('can report a command', function () {
     test()->flare->tracer->startTrace();
 
-    $flare->tracer->startTrace();
-
     test()->consoleKernel->call('flare:test-command');
 
     $report = test()->flare->report(


### PR DESCRIPTION
The "Run tests" job was failing across every OS and version in the matrix because `CommandRecorderTest` referenced an undefined `$flare` variable on a stray line, which threw `Undefined variable $flare` and failed the suite. That line was a leftover duplicate of the line above it, which already starts the trace correctly via `test()->flare`. Removing it greens the suite (all 5 tests in the file pass locally).