### PR TITLE
Add configuring() hook to mutate FlareConfig before Flare boots

### DIFF
--- a/src/Facades/Flare.php
+++ b/src/Facades/Flare.php
@@ -40,9 +40,9 @@ class Flare extends Facade
     /**
      * @param Closure(FlareConfig):void $callback
      */
-    public static function configuring(Closure $callback): void
+    public static function configure(Closure $callback): void
     {
-        FlareServiceProvider::configuring($callback);
+        FlareServiceProvider::configure($callback);
     }
 
     /**

--- a/src/Facades/Flare.php
+++ b/src/Facades/Flare.php
@@ -11,6 +11,7 @@ use Spatie\FlareClient\Recorders\GlowRecorder\GlowRecorder;
 use Spatie\FlareClient\Recorders\ResponseRecorder\ResponseRecorder;
 use Spatie\FlareClient\Tracer;
 use Spatie\LaravelFlare\FlareConfig;
+use Spatie\LaravelFlare\FlareServiceProvider;
 use Spatie\LaravelFlare\Recorders\FilesystemRecorder\FilesystemRecorder;
 use Spatie\LaravelFlare\Recorders\RequestRecorder\RequestRecorder;
 use Spatie\LaravelFlare\Recorders\RoutingRecorder\RoutingRecorder;
@@ -34,6 +35,14 @@ class Flare extends Facade
     protected static function getFacadeAccessor()
     {
         return FlareClient::class;
+    }
+
+    /**
+     * @param Closure(FlareConfig):void $callback
+     */
+    public static function configuring(Closure $callback): void
+    {
+        FlareServiceProvider::configuring($callback);
     }
 
     /**

--- a/src/Facades/Flare.php
+++ b/src/Facades/Flare.php
@@ -11,7 +11,6 @@ use Spatie\FlareClient\Recorders\GlowRecorder\GlowRecorder;
 use Spatie\FlareClient\Recorders\ResponseRecorder\ResponseRecorder;
 use Spatie\FlareClient\Tracer;
 use Spatie\LaravelFlare\FlareConfig;
-use Spatie\LaravelFlare\FlareServiceProvider;
 use Spatie\LaravelFlare\Recorders\FilesystemRecorder\FilesystemRecorder;
 use Spatie\LaravelFlare\Recorders\RequestRecorder\RequestRecorder;
 use Spatie\LaravelFlare\Recorders\RoutingRecorder\RoutingRecorder;
@@ -35,14 +34,6 @@ class Flare extends Facade
     protected static function getFacadeAccessor()
     {
         return FlareClient::class;
-    }
-
-    /**
-     * @param Closure(FlareConfig):void $callback
-     */
-    public static function configure(Closure $callback): void
-    {
-        FlareServiceProvider::configure($callback);
     }
 
     /**

--- a/src/FlareServiceProvider.php
+++ b/src/FlareServiceProvider.php
@@ -110,7 +110,7 @@ class FlareServiceProvider extends ServiceProvider
     /**
      * @param Closure(FlareConfig):void $callback
      */
-    public static function configuring(Closure $callback): void
+    public static function configure(Closure $callback): void
     {
         static::$configurationCallbacks[] = $callback;
     }

--- a/src/FlareServiceProvider.php
+++ b/src/FlareServiceProvider.php
@@ -52,6 +52,9 @@ use Spatie\LaravelFlare\Views\ViewFrameMapper;
 
 class FlareServiceProvider extends ServiceProvider
 {
+    /** @var array<int, Closure(FlareConfig):void> */
+    protected static array $configurationCallbacks = [];
+
     protected FlareProvider $provider;
 
     protected FlareConfig $config;
@@ -104,12 +107,29 @@ class FlareServiceProvider extends ServiceProvider
         $this->disableApiQueue = $this->disableApiQueue || ($this->app->runningInConsole() && isset($_SERVER['argv']) && in_array('tinker', $_SERVER['argv']));
     }
 
+    /**
+     * @param Closure(FlareConfig):void $callback
+     */
+    public static function configuring(Closure $callback): void
+    {
+        static::$configurationCallbacks[] = $callback;
+    }
+
+    public static function flushConfigurationCallbacks(): void
+    {
+        static::$configurationCallbacks = [];
+    }
+
     public function register(): void
     {
         if (! $this->app->has(FlareConfig::class)) {
             $this->mergeConfigFrom(__DIR__.'/../config/flare.php', 'flare');
 
             $this->config = FlareConfig::fromLaravelConfig();
+
+            foreach (static::$configurationCallbacks as $callback) {
+                $callback($this->config);
+            }
 
             $this->app->singleton(FlareConfig::class, fn () => $this->config);
         } else {

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -63,8 +63,8 @@ it('runs configuring callbacks against the config before it is used to boot Flar
     FlareServiceProvider::flushConfigurationCallbacks();
     config()->set('flare.key', 'some-key');
 
-    FlareServiceProvider::configuring(fn (FlareConfig $config) => $config->applicationName = 'first');
-    FlareFacade::configuring(function (FlareConfig $config) {
+    FlareServiceProvider::configure(fn (FlareConfig $config) => $config->applicationName = 'first');
+    FlareFacade::configure(function (FlareConfig $config) {
         $config->applicationName = 'from-hook';
         $config->configureResource(fn (Resource $resource) => $resource->addAttribute('custom.attribute', 'value'));
     });

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -8,6 +8,7 @@ use Spatie\FlareClient\Flare;
 use Spatie\FlareClient\Resources\Resource;
 use Spatie\FlareClient\Tests\Shared\FakeApi;
 use Spatie\FlareClient\Tests\Shared\FakeTime;
+use Spatie\LaravelFlare\Facades\Flare as FlareFacade;
 use Spatie\LaravelFlare\FlareConfig;
 use Spatie\LaravelFlare\FlareServiceProvider;
 
@@ -63,7 +64,7 @@ it('runs configuring callbacks against the config before it is used to boot Flar
     config()->set('flare.key', 'some-key');
 
     FlareServiceProvider::configuring(fn (FlareConfig $config) => $config->applicationName = 'first');
-    FlareServiceProvider::configuring(function (FlareConfig $config) {
+    FlareFacade::configuring(function (FlareConfig $config) {
         $config->applicationName = 'from-hook';
         $config->configureResource(fn (Resource $resource) => $resource->addAttribute('custom.attribute', 'value'));
     });

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -8,7 +8,6 @@ use Spatie\FlareClient\Flare;
 use Spatie\FlareClient\Resources\Resource;
 use Spatie\FlareClient\Tests\Shared\FakeApi;
 use Spatie\FlareClient\Tests\Shared\FakeTime;
-use Spatie\LaravelFlare\Facades\Flare as FlareFacade;
 use Spatie\LaravelFlare\FlareConfig;
 use Spatie\LaravelFlare\FlareServiceProvider;
 
@@ -64,7 +63,7 @@ it('runs configuring callbacks against the config before it is used to boot Flar
     config()->set('flare.key', 'some-key');
 
     FlareServiceProvider::configure(fn (FlareConfig $config) => $config->applicationName = 'first');
-    FlareFacade::configure(function (FlareConfig $config) {
+    FlareServiceProvider::configure(function (FlareConfig $config) {
         $config->applicationName = 'from-hook';
         $config->configureResource(fn (Resource $resource) => $resource->addAttribute('custom.attribute', 'value'));
     });

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -1,11 +1,15 @@
 <?php
 
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\View;
 use Spatie\FlareClient\Flare;
+use Spatie\FlareClient\Resources\Resource;
 use Spatie\FlareClient\Tests\Shared\FakeApi;
 use Spatie\FlareClient\Tests\Shared\FakeTime;
+use Spatie\LaravelFlare\FlareConfig;
+use Spatie\LaravelFlare\FlareServiceProvider;
 
 beforeEach(function () {
     Artisan::call('view:clear');
@@ -52,4 +56,22 @@ it('will not trace, log or report when flare is disabled', function () {
     Log::critical("test");
 
     FakeApi::assertSent(reports: 0, traces: 0, logs: 0);
+});
+
+it('runs configuring callbacks against the config before it is used to boot Flare', function () {
+    FlareServiceProvider::flushConfigurationCallbacks();
+    config()->set('flare.key', 'some-key');
+
+    FlareServiceProvider::configuring(fn (FlareConfig $config) => $config->applicationName = 'first');
+    FlareServiceProvider::configuring(function (FlareConfig $config) {
+        $config->applicationName = 'from-hook';
+        $config->configureResource(fn (Resource $resource) => $resource->addAttribute('custom.attribute', 'value'));
+    });
+
+    app()->register(new FlareServiceProvider(resolve(Application::class)));
+
+    expect(app(FlareConfig::class)->applicationName)->toBe('from-hook');
+    expect(app(Resource::class)->attributes)->toHaveKey('custom.attribute', 'value');
+
+    FlareServiceProvider::flushConfigurationCallbacks();
 });


### PR DESCRIPTION
Adds a `FlareServiceProvider::configure()` hook that runs callbacks against the `FlareConfig` after it is hydrated from the config file but before Flare uses it to register, giving applications a well timed seam to change config that is consumed during registration (recorders, sampler, sender, and the resource) which cannot be expressed in a cached config file, for example a `configureResource()` closure that adds attributes to the resource. Because auto discovered package providers register before the application's own providers, a service provider is too late, so the callback must be registered inside the `withExceptions()` block in `bootstrap/app.php`, right next to `Flare::handles()`, which runs before Flare registers. Verified end to end against `spatie/flare-debug-sender`: an attribute added through the hook appears in the resource of the sent trace payload. A test in `FlareTest.php` covers callback ordering, config mutation, and the attribute reaching the resolved resource.