### PR TITLE
Guard FlareTracingMiddleware::terminate against uninitialized request

### DIFF
--- a/src/Http/Middleware/FlareTracingMiddleware.php
+++ b/src/Http/Middleware/FlareTracingMiddleware.php
@@ -55,12 +55,14 @@ class FlareTracingMiddleware
 
     public function terminate(Request $request, Response $response): void
     {
-        Flare::request()?->recordEnd(
-            requestAttributesProvider: $this->requestAttributesProvider,
-            responseAttributesProvider: new SymfonyResponseAttributesProvider($this->redactor, $response),
-            routeAttributesProvider: self::$routeAttributesProvider ?? LaravelRouteAttributesProvider::fromRequest($request),
-            userAttributesProvider: LaravelUserAttributesProvider::fromRequest($request),
-        );
+        if (isset($this->requestAttributesProvider)) {
+            Flare::request()?->recordEnd(
+                requestAttributesProvider: $this->requestAttributesProvider,
+                responseAttributesProvider: new SymfonyResponseAttributesProvider($this->redactor, $response),
+                routeAttributesProvider: self::$routeAttributesProvider ?? LaravelRouteAttributesProvider::fromRequest($request),
+                userAttributesProvider: LaravelUserAttributesProvider::fromRequest($request),
+            );
+        }
 
         self::$routeAttributesProvider = null;
 


### PR DESCRIPTION
## Problem

Users on Vapor (and any early-request-error scenario) saw this reported to Flare:

> Typed property `Spatie\LaravelFlare\Http\Middleware\FlareTracingMiddleware::$requestAttributesProvider` must not be accessed before initialization

This is a secondary error that masks the real one.

## Cause

`FlareTracingMiddleware` sets `$requestAttributesProvider` in `handle()` and reads it in `terminate()`. Laravel's kernel calls `bootstrap()` before building the middleware pipeline (`sendRequestThroughRouter`). If anything throws during bootstrap, the pipeline is never built, so `handle()` never runs. The exception is caught and a response is rendered, then `terminate()` still fires on every global terminable middleware regardless of whether its `handle()` ran (`terminateMiddleware`).

The result: `terminate()` accesses a typed property that was never initialized and throws a fatal error. That crash gets reported to Flare, hiding the original bootstrap-time failure (a common one when migrating an old app from Ignition, where leftover config or providers throw during boot).

## Fix

Guard the request-end recording with `isset()`. The lifecycle `terminating()` call is preserved so nothing else in the shutdown path changes. When `handle()` never ran, we simply skip recording the request span instead of crashing, letting the real error surface.
