### PR TITLE
Add max_attribute_size_in_kb trace limit config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "illuminate/support": "^10.0|^11.47|^12.42|^13.0",
-        "spatie/flare-client-php": "^3.2.1",
+        "spatie/flare-client-php": "^3.3.0",
         "spatie/laravel-error-share": "^1.0.3",
         "symfony/console": "^6.4|^7.2.1|^8.0",
         "symfony/var-dumper": "^6.4|^7.2.3|^8.0"

--- a/config/flare.php
+++ b/config/flare.php
@@ -192,6 +192,7 @@ return [
         'max_attributes_per_span' => 128,
         'max_span_events_per_span' => 128,
         'max_attributes_per_span_event' => 128,
+        'max_attribute_size_in_kb' => 32,
     ],
 
     /*


### PR DESCRIPTION
Laravel counterpart to spatie/flare-client-php#85, which trims oversized span attributes at record time to bound retained trace memory. Adds the mirrored `max_attribute_size_in_kb` key (default 32KB) under `trace_limits` in `config/flare.php`, and bumps the `spatie/flare-client-php` requirement to `^3.3.0` where the trimming logic lives.