### PR TITLE
Ignore framework and vendor cache keys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "illuminate/support": "^10.0|^11.47|^12.42|^13.0",
-        "spatie/flare-client-php": "^3.3.0",
+        "spatie/flare-client-php": "^3.4.1",
         "spatie/laravel-error-share": "^1.0.3",
         "symfony/console": "^6.4|^7.2.1|^8.0",
         "symfony/var-dumper": "^6.4|^7.2.3|^8.0"

--- a/src/FlareConfig.php
+++ b/src/FlareConfig.php
@@ -146,6 +146,7 @@ class FlareConfig extends BaseFlareConfig
                 'with_errors' => CacheRecorder::DEFAULT_WITH_ERRORS,
                 'max_items_with_errors' => CacheRecorder::DEFAULT_MAX_ITEMS_WITH_ERRORS,
                 'operations' => CacheRecorder::DEFAULT_OPERATIONS,
+                'ignored_keys' => [],
             ],
             CollectType::LogsWithErrors->value => [
                 'max_items' => AddLogs::DEFAULT_MAX_LOGS_WITH_ERRORS,

--- a/src/Recorders/CacheRecorder/CacheRecorder.php
+++ b/src/Recorders/CacheRecorder/CacheRecorder.php
@@ -44,4 +44,21 @@ class CacheRecorder extends BaseCacheRecorder
             $event->storeName ?? null,
         ));
     }
+
+    /** @return array<int, string> */
+    protected function defaultIgnoredKeys(): array
+    {
+        return [
+            '/^illuminate:(?!cache:flexible:created:)/',
+            '/^framework\/schedule/',
+            '/^laravel_vapor_job_attempt?s:/',
+            '/^laravel:pulse:/',
+            '/^laravel:reverb:/',
+            '/^laravel:horizon:/',
+            '/^horizon:/',
+            '/^nova/',
+            '/^telescope:/',
+            '/^livewire-checksum-failures:/',
+        ];
+    }
 }

--- a/tests/Recorders/CacheRecorder/CacheRecorderTest.php
+++ b/tests/Recorders/CacheRecorder/CacheRecorderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
 use function Pest\Laravel\get;
@@ -7,6 +8,7 @@ use Spatie\FlareClient\Enums\CacheOperation;
 use Spatie\FlareClient\Enums\CacheResult;
 use Spatie\FlareClient\Enums\SpanEventType;
 use Spatie\FlareClient\Tests\Shared\FakeApi;
+use Spatie\LaravelFlare\FlareConfig;
 
 beforeEach(function () {
     config()->set('cache.default', 'array');
@@ -42,6 +44,77 @@ it('records cache operations', function (
 
     $assert($cacheSpanEvents[0]);
 })->with('cache recorder');
+
+it('ignores framework and vendor cache keys', function () {
+    Cache::clear();
+
+    setupFlare();
+
+    Route::get('exception', function () {
+        cache()->get('illuminate:queue:restart');
+
+        throw new Exception('This is a failed operation');
+    });
+
+    get('exception')->assertStatus(500);
+
+    $cacheSpanEvents = array_values(array_filter(
+        FakeApi::lastReport()->toArray()['events'],
+        fn (array $event) => $event['type'] === SpanEventType::Cache,
+    ));
+
+    expect($cacheSpanEvents)->toHaveCount(0);
+});
+
+it('does not ignore keys written by flexible since they contain a user defined key', function () {
+    Cache::clear();
+
+    setupFlare();
+
+    Route::get('exception', function () {
+        Cache::flexible('some_key', [5, 10], fn () => 'some_value');
+
+        throw new Exception('This is a failed operation');
+    });
+
+    get('exception')->assertStatus(500);
+
+    $cacheSpanEvents = array_values(array_filter(
+        FakeApi::lastReport()->toArray()['events'],
+        fn (array $event) => $event['type'] === SpanEventType::Cache,
+    ));
+
+    expect(array_column(array_column($cacheSpanEvents, 'attributes'), 'cache.key'))
+        ->toContain('illuminate:cache:flexible:created:some_key');
+})->skip(
+    fn () => ! method_exists(Repository::class, 'flexible'),
+    'Cache::flexible() requires Laravel 11.23 or higher',
+);
+
+it('can ignore additional cache keys', function () {
+    Cache::clear();
+
+    setupFlare(fn (FlareConfig $config) => $config->collectCacheEvents(
+        ignoredKeys: ['/^internal:/'],
+    ));
+
+    Route::get('exception', function () {
+        cache()->get('internal:some_key');
+        cache()->get('some_key');
+
+        throw new Exception('This is a failed operation');
+    });
+
+    get('exception')->assertStatus(500);
+
+    $cacheSpanEvents = array_values(array_filter(
+        FakeApi::lastReport()->toArray()['events'],
+        fn (array $event) => $event['type'] === SpanEventType::Cache,
+    ));
+
+    expect($cacheSpanEvents)->toHaveCount(1);
+    expect($cacheSpanEvents[0]['attributes']['cache.key'])->toBe('some_key');
+});
 
 dataset('cache recorder', function () {
     yield 'cache hit' => [


### PR DESCRIPTION
Laravel and its first party packages write a lot of cache keys that are noise for the user, so the `CacheRecorder` now skips them through `defaultIgnoredKeys()`: framework internals, the scheduler, Vapor, Pulse, Reverb, Horizon, Nova, Telescope and Livewire checksum failures.

Keys written by `Cache::flexible()` are deliberately kept, since they embed a user defined key under the `illuminate:` prefix rather than being framework noise. That exception is a lookahead in the first pattern.

Users can add their own patterns through the new `ignored_keys` option, which is added to the built in list rather than replacing it. Patterns are regexes including delimiters, matching how the option works in the client package.

Requires `spatie/flare-client-php` 3.4.1, which adds the `ignored_keys` option and the `defaultIgnoredKeys()` hook.