### PR TITLE
Fix test failures caused by Laravel 13 and Guzzle 8

### DIFF
--- a/src/AttributesProviders/LaravelJobAttributesProvider.php
+++ b/src/AttributesProviders/LaravelJobAttributesProvider.php
@@ -254,6 +254,7 @@ class LaravelJobAttributesProvider implements JobAttributesProvider, SamplingAtt
             'messageGroup',
             'deduplicator',
             'debounceOwner',
+            'uniqueLockOwner',
             'tries',
         ];
 

--- a/src/Recorders/ExternalHttpRecorder/Guzzle/FlareHandlerStack.php
+++ b/src/Recorders/ExternalHttpRecorder/Guzzle/FlareHandlerStack.php
@@ -2,13 +2,15 @@
 
 namespace Spatie\LaravelFlare\Recorders\ExternalHttpRecorder\Guzzle;
 
+use GuzzleHttp\HandlerStack;
 use Spatie\FlareClient\Flare;
 use Spatie\FlareClient\Recorders\ExternalHttpRecorder\Guzzle\FlareHandlerStack as BaseFlareHandlerStack;
 
-class FlareHandlerStack extends BaseFlareHandlerStack
+class FlareHandlerStack
 {
-    public function __construct(?callable $handler = null)
+    /** @return HandlerStack<callable> */
+    public static function create(?callable $handler = null): HandlerStack
     {
-        parent::__construct(app(Flare::class), $handler);
+        return BaseFlareHandlerStack::create(app(Flare::class), $handler);
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Composer\InstalledVersions;
+use GuzzleHttp\ClientInterface;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Queue\CallQueuedClosure;
@@ -59,7 +60,7 @@ describe('Laravel integration', function () {
             ->expectAttribute('flare.entry_point.handler.type', 'laravel_closure')
             ->expectHasAttribute('server.address')
             ->expectHasAttribute('server.port')
-            ->expectAttribute('user_agent.original', 'GuzzleHttp/7')
+            ->expectAttribute('user_agent.original', 'GuzzleHttp/'.ClientInterface::MAJOR_VERSION)
             ->expectAttribute('http.request.body.size', 0)
             ->expectHasAttribute('client.address')
             ->expectHasAttribute('http.request.headers')


### PR DESCRIPTION
Laravel 13 added a `uniqueLockOwner` property to the `Queueable` trait, which leaked into the reported job properties. It is an internal lock token rather than user data, so it now sits alongside `debounceOwner` and `deduplicator` in the list of properties we skip.

The integration test also asserted a hardcoded `GuzzleHttp/7` user agent, which fails now that Guzzle 8 resolves on prefer-stable. It derives the major version from the installed Guzzle instead.

Finally, `FlareHandlerStack` needed updating. The client turned it from a `HandlerStack` subclass with a constructor into a plain class with a static `create()` method, so our subclass called a parent constructor that no longer exists. That is a fatal error for anyone using the class, not just a static analysis warning.

Main currently fails on the Laravel 13 prefer-stable jobs for these reasons, so this is not caused by any change in this branch.